### PR TITLE
Added datatables plugin that neutralises diacritics

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,8 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/t/bs-3.3.6/jqc-1.12.0,dt-1.10.11,r-2.0.2/datatables.min.css">
     <link rel="stylesheet" type="text/css" href="css/style.css">
     <script type="text/javascript" src="https://cdn.datatables.net/t/bs-3.3.6/jqc-1.12.0,dt-1.10.11,r-2.0.2/datatables.min.js"></script>
+    <script type="text/javascript" src="//cdn.datatables.net/plug-ins/1.10.16/filtering/type-based/diacritics-neutralise.js"></script>
+
     <!-- Cookie Policy -->
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -106,8 +106,8 @@ function initMap() {
                 tabledata = JSON.parse("[" + localStorage.placeData.slice(0, -1) + "]") || [];
             }
             tabledata.map(placeMapper);
-            //Datatable options go here! 
-            $('#datatablex').DataTable({
+            //Datatable options go here!
+            var $tablex = $('#datatablex').DataTable({
                 "responsive": true,
                 "processing": true,
                 "columnDefs": [
@@ -137,6 +137,14 @@ function initMap() {
         ]
 
             });
+
+            // Replace diacritics in search as well to allow search input that has diacritics
+            $('#datatablex_filter input[type=search]').keyup( function () {
+              $tablex.search(
+                  jQuery.fn.DataTable.ext.type.search.string( this.value )
+                )
+                .draw()
+            } );
         });
         //Smootly scroll to the datatable when a row is clicked
         $('a[data-toggle="pill"], a[class="btn btn-primary btn-lg btn-block"] ').on('click', function () {
@@ -147,9 +155,8 @@ function initMap() {
     })
 };
 
-$('#datatableAdded').dataTable({
-    "sAjaxSource": "js/dataAdded.json",
-    "sAjaxDataProp": "data",
+var $tableAdded = $('#datatableAdded').DataTable({
+    "ajax": "js/dataAdded.json",
     "responsive": true,
     "processing": true,
     "columns": [
@@ -167,4 +174,11 @@ $('#datatableAdded').dataTable({
             return '<a href="' + data + '" target="_blank">Link</a>';
         }
   }]
-})
+});
+
+$('#datatableAdded_filter input[type=search]').on("keyup", function () {
+  $tableAdded.search(
+      jQuery.fn.DataTable.ext.type.search.string( this.value )
+    )
+    .draw()
+} );


### PR DESCRIPTION
Added datatables plugin that neutralises diacritics. By default the plugin neutralises only the results so this PR includes a fix that will also neutralise the input string in the search box.